### PR TITLE
Configure pythontests.yml

### DIFF
--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -1,0 +1,34 @@
+name: Python app tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Run pytest on ${{ matrix.os }} and python ${{ matrix.python_version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python_version: ['3.6', '3.7', '3.8']
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+      
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up python ${{ matrix.python_version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python_version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest


### PR DESCRIPTION
Configure new Github CI feature to trigger auto integration tests on each new push / pull request. The tests try out each windows/macos/linux and python 3.6/3.7/3.8 combination.